### PR TITLE
Prepare for SIP-56 match types.

### DIFF
--- a/protocol-core/src/main/scala/io/github/kory33/s2mctest/core/generic/compiletime/Generic.scala
+++ b/protocol-core/src/main/scala/io/github/kory33/s2mctest/core/generic/compiletime/Generic.scala
@@ -9,7 +9,7 @@ import scala.annotation.implicitNotFound
  * @see
  *   [[IncludedInLockedT]] for an example usage.
  */
-type Lock[X]
+sealed trait Lock[X]
 
 /**
  * An implicit evidence that the type [[S]] can be reduced to the singleton type [[true]].

--- a/protocol-core/src/test/scala/io/github/kory33/s2mctest/core/generic/compiletime/TupleSpec.scala
+++ b/protocol-core/src/test/scala/io/github/kory33/s2mctest/core/generic/compiletime/TupleSpec.scala
@@ -10,16 +10,11 @@ class TupleSpec extends AnyFlatSpec with should.Matchers {
     summon[IncludedInT[(Int, String, Double), Double] =:= true]
 
     summon[IncludedInT[EmptyTuple, Any] =:= false]
-    summon[IncludedInT[(Int, String, Double), Any] =:= false]
-    summon[IncludedInT[(Int, String, Double), 1] =:= false]
-    summon[IncludedInT[(Int, String, Double), Int | String] =:= false]
     summon[IncludedInT[(Int, String, Double), Float] =:= false]
   }
 
   "IndexOfT" should "extract the index of a specific type from a tuple" in {
     summon[IndexOfT[Int, (String, Int)] =:= 1]
-    summon[IndexOfT[42, (String, Int, 42)] =:= 2]
-    summon[IndexOfT[Int, (String | Int, Double, Int)] =:= 2]
 
     "summon[IndexOfT[42, (0, 0)] =:= 0]" shouldNot compile
     "summon[IndexOfT[42, (0, 0)] =:= 1]" shouldNot compile


### PR DESCRIPTION
Of the entire ecosystem of Scala 2 libraries, s2mc is the most affected by the new match types of SIP-56. Some of it was decidedly unsound and can be fixed by local rewriting, which we do in the first 2 commits.

Some tests are not fundamentally shown to be unsound but did rely on some implementation-defined behavior of the old match types, which is not supported anymore. It does not seem to me like the larger project needs those particular tests to pass to be meaningful. So we suggest to remove them, and focus on types that are actually provably disjoint.